### PR TITLE
Updates

### DIFF
--- a/Functions/Get-AutomoxAPIObject.ps1
+++ b/Functions/Get-AutomoxAPIObject.ps1
@@ -47,6 +47,10 @@ Function Get-AutomoxAPIObject
           Specifies whether to request the associated data with a given object based on the API endpoint.
           An example would be, when querying device information, this argument would fetch the installed software on each device returned from the API request.
 
+          .PARAMETER RequestAssociatedData
+          Specifies whether to request the associated data with a given object based on the API endpoint.
+          An example would be, when querying device information, this argument would fetch the installed software on each device returned from the API request.
+
           .PARAMETER Export
           Specifies that the API request results should be exported.
 

--- a/Functions/Get-AutomoxAPIObject.ps1
+++ b/Functions/Get-AutomoxAPIObject.ps1
@@ -513,8 +513,8 @@ Function Get-AutomoxAPIObject
                                                                               
                                                                               {($_ -iin @('servers'))}
                                                                                 {
-                                                                                    $RequiredRequestParameters.Add("include_details=1")
-                                                                                    $RequiredRequestParameters.Add("include_server_events=1")
+                                                                                    #$RequiredRequestParameters.Add("include_details=1")
+                                                                                    #$RequiredRequestParameters.Add("include_server_events=1")
                                                                                 }
                                                                                 
                                                                               Default

--- a/Functions/Get-AutomoxAPIObject.ps1
+++ b/Functions/Get-AutomoxAPIObject.ps1
@@ -513,8 +513,8 @@ Function Get-AutomoxAPIObject
                                                                               
                                                                               {($_ -iin @('servers'))}
                                                                                 {
-                                                                                    #$RequiredRequestParameters.Add("include_details=1")
-                                                                                    #$RequiredRequestParameters.Add("include_server_events=1")
+                                                                                    $RequiredRequestParameters.Add("include_details=1")
+                                                                                    $RequiredRequestParameters.Add("include_server_events=1")
                                                                                 }
                                                                                 
                                                                               Default


### PR DESCRIPTION
Product has made a change to our servers API that I plan to communicate to customers that have used that API in the past. 

Automox is improving the performance of its server APIs by changing how detailed data is provided!  Previously, certain details like server specifications, upcoming patch times, and event counts were included automatically in every API request, which could slow down response times. Going forward, users will need to explicitly request this additional data using specific parameters, ensuring faster responses when these details aren’t needed.

For instance, skipping the "next patch time" calculation alone can make queries up to 10 times faster. This change enhances efficiency, particularly for organizations managing many devices, while still allowing access to detailed information when required by adding the appropriate parameters to the request.

To learn more about how to add specific parameters back in, please refer to [this technical documentation]

(https://developer.automox.com/developer-portal/servers-fast-by-default/).